### PR TITLE
Fix tvOS build warnings

### DIFF
--- a/PocketSocket.xcodeproj/project.pbxproj
+++ b/PocketSocket.xcodeproj/project.pbxproj
@@ -478,6 +478,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				ONLY_ACTIVE_ARCH = NO;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos appletvsimulator";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
 		};
@@ -511,6 +512,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos appletvsimulator";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;


### PR DESCRIPTION
Set tvOS deployment target of the project to 9.0.

Reference: https://github.com/couchbase/couchbase-lite-ios/issues/1387
