### PR TITLE
Fix crash when delegate validates server trust

### DIFF
--- a/PocketSocket/PSWebSocket.m
+++ b/PocketSocket/PSWebSocket.m
@@ -613,8 +613,10 @@
         return;
     SecTrustRef trust = (__bridge SecTrustRef)[stream propertyForKey: (__bridge id)kCFStreamPropertySSLPeerTrust];
     NSAssert(trust != nil, @"Couldn't get SSL trust");
+    CFRetain(trust);
     [self executeDelegate:^{
         BOOL ok = [_delegate webSocket: self validateServerTrust: trust];
+        CFRelease(trust);
         [self executeWork:^{
             if (ok) {
                 _serverUnvalidated = NO;


### PR DESCRIPTION
Manually retained and released trust as the validation is done asyncrhonously in block.

Ticket: https://github.com/couchbase/couchbase-lite-ios/issues/1613